### PR TITLE
Zustand userStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5566,6 +5566,12 @@
         }
       }
     },
+    "boganipsum": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/boganipsum/-/boganipsum-0.2.0.tgz",
+      "integrity": "sha512-JG2TUul3L9U8Dg+AiqzfC27nTvGeMcuxg39dvICEq+fnTZjvV2NychKnevl7D6+DLk/NbUHGPGxBC9/NHrcVlQ==",
+      "dev": true
+    },
     "bonjour": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18643,9 +18643,9 @@
       }
     },
     "zustand": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-2.2.1.tgz",
-      "integrity": "sha512-K0GO3fe4RxhUWJo3yu9ET16FxPpwHR7EZg3du/c2q1p8QEarzSxqmT9J+Gip4cAV8tapL17h99GbsBsmqq55WA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-2.2.2.tgz",
+      "integrity": "sha512-l51p5Ys4WcAqrds1pCd/lWQU5jzyayzyftyTmtwawhLLl/V9Wn9D0aX5Wu2fZ8XOco4C87UrurRVJ0Y/rNNrtg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/addon-knobs": "^5.3.8",
     "@storybook/addon-links": "^5.3.8",
     "@storybook/addons": "^5.3.8",
-    "@storybook/react": "^5.3.8"
+    "@storybook/react": "^5.3.8",
+    "boganipsum": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "three": "^0.111.0",
     "use-interval": "^1.2.1",
     "use-timeout": "^1.1.0",
-    "zustand": "^2.2.1"
+    "zustand": "^2.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import {Enclosure} from './components/core/Wall'
 
 import Seseme from './components/projects/seseme'
 import Eclipse from './components/projects/Eclipse'
-import Scorecard from './components/projects/Scorecard/'
+import Scorecard, {SCBlurb, SCPage} from './components/projects/Scorecard/'
 
 import {CameraProvider} from './components/core/Camera'
 
@@ -24,13 +24,17 @@ export const WorldFunctions = React.createContext({
   //insert functions that every child of the world should have? 
 })
 
+
+export const UserContext = React.createContext({})
+
 function App() {
 
   const isInitialMount = useRef(true)
 
-  const [selected, select] = useState(null)
+  const [selected, select] = useState(null) //blurb
+  const [studying, study] = useState(null) //page
   const [abyss, admitToAbyss] = useState([]) //for removing projects as they fall out of view 
-  const [camStatus, setCamStatus] = useState(null)
+
 
   useEffect(()=>{
     if(isInitialMount.current){
@@ -42,17 +46,12 @@ function App() {
     }
   }, [selected])
 
-  useEffect(()=>{
-    console.log('cam status changed: ', camStatus)
-  }, [camStatus])
-
-  const [useCamera, chooseCamera] = useState('default')
-  const [adjustOffset, changeAdjOffset] = useState({
-    position: [0,0,0], rotation: [0,0,0], fov: 0
-  })
 
   return (
     <div className = 'full'>
+      <UserContext.Provider value = {{
+        study: study, studying: studying,
+      }}>
       <Canvas 
         invalidateFrameloop = {false}
         onPointerMissed = {()=> select(null)}
@@ -101,9 +100,17 @@ function App() {
         </PhysicsProvider>
 
       </Canvas>
-   
-      <InfoBlurb />
-      <InfoPage />
+      {selected &&
+        <InfoBlurb>
+          {selected === 'scorecard' && <SCBlurb />}
+        </InfoBlurb>
+      }
+      {studying &&
+      <InfoPage>
+        {studying === 'scorecard' && <SCPage />}
+      </InfoPage>
+      }
+      </UserContext.Provider>
 
     </div>
   );
@@ -113,14 +120,14 @@ function App() {
 const InfoBlurb = styled.div`
   position: absolute;
   border: 1px solid red;
-  width: 33%;
+  width: 50%;
   height: 500px;
   top: 0; bottom: 0; margin: auto 0;
   right: 0;
 `
 
 const InfoPage = styled.div`
-display: none;
+// display: none;
   border: 1px solid black;
   width: 66%; 
   height: 100%; 

--- a/src/App.js
+++ b/src/App.js
@@ -22,11 +22,6 @@ import Projects from './components/core/Projects'
  
 import {toRads, toDegs} from './utils/3d'
 
-
-export const WorldFunctions = React.createContext({
-  //insert functions that every child of the world should have? 
-})
-
 export const [userStore] = create(set => ({
   selected: null, select: v => set({selected: v}),
   studying: null, study: v => set({studying: v}),
@@ -66,10 +61,6 @@ function App() {
         props = {{antialias: false}}
       >
         <PhysicsProvider>
-            <WorldFunctions.Provider value = {{
-              abyss: abyss,
-              admitToAbyss: admitToAbyss,
-            }}>
             <CameraProvider>
             <Enclosure
               active = {!selected} 
@@ -98,7 +89,6 @@ function App() {
             
             </Projects>
             </CameraProvider>
-            </WorldFunctions.Provider>
             
 
         </PhysicsProvider>

--- a/src/components/core/Physics.js
+++ b/src/components/core/Physics.js
@@ -57,7 +57,7 @@ export function usePhysics({ ...props}, fn, deps = [], name){
     if(ref.current){ 
         if(body.position.y< -20 && !abyss.includes(name)){
           console.log('admitting', name, 'to abyss')
-          admitToAbyss([abyss, name])
+          admitToAbyss([...abyss, name])
           if(!selected){
             // console.log('rapid undo: reinserting object')
             admitToAbyss([])

--- a/src/components/core/Physics.js
+++ b/src/components/core/Physics.js
@@ -5,7 +5,7 @@ import TWEEN from '@tweenjs/tween.js'
 
 import {userStore} from '../../App'
 
-const physicsContext = React.createContext()
+export const physicsContext = React.createContext()
 export function PhysicsProvider({children}){
   const [world] = useState(()=> new CANNON.World())
   const [abyss, admitToAbyss] = useState([])

--- a/src/components/core/Physics.js
+++ b/src/components/core/Physics.js
@@ -3,11 +3,13 @@ import {useFrame} from 'react-three-fiber'
 import * as CANNON from 'cannon'
 import TWEEN from '@tweenjs/tween.js'
 
-import {WorldFunctions} from '../../App'
+import {userStore} from '../../App'
 
 const physicsContext = React.createContext()
 export function PhysicsProvider({children}){
   const [world] = useState(()=> new CANNON.World())
+  const [abyss, admitToAbyss] = useState([])
+
   useEffect(() => {
     console.log('WORLD:')
     console.log(world)
@@ -25,20 +27,19 @@ export function PhysicsProvider({children}){
   window.world = world
 
   //world is provided as context for all components
-  return <physicsContext.Provider value = {world} children = {children} />
+  return <physicsContext.Provider value = {{world: world, abyss: abyss, admitToAbyss: admitToAbyss}} children = {children} />
 }
 
 //cannon hook for tracking/updating a physics obj
 //usePhysics(cannon properties, a function to call on the body created herein, deps????)
 export function usePhysics({ ...props}, fn, deps = [], name){
 
-  const worldFuncContext = useContext(WorldFunctions)
-
   let isSleep
   const ref = useRef()
 
   //use provided context: will get value (world info) from nearest parent cannonProvider
-  const world = useContext(physicsContext) //not known: do i need to have a const context = React.createContext() every time i make a component that uses context...???
+  const selected = userStore(store => store.selected)
+  const {world, abyss, admitToAbyss} = useContext(physicsContext) //not known: do i need to have a const context = React.createContext() every time i make a component that uses context...???
 
   //instantiate body for whoever is using usePhysics
   const [body] = useState(()=> new CANNON.Body(props))
@@ -54,12 +55,12 @@ export function usePhysics({ ...props}, fn, deps = [], name){
   
   useFrame(()=>{    
     if(ref.current){ 
-        if(body.position.y< -20 && !worldFuncContext.abyss.includes(name)){
-          // console.log('admitting', name, 'to abyss')
-          worldFuncContext.admitToAbyss([...worldFuncContext.abyss, name])
-          if(!worldFuncContext.selected){
+        if(body.position.y< -20 && !abyss.includes(name)){
+          console.log('admitting', name, 'to abyss')
+          admitToAbyss([abyss, name])
+          if(!selected){
             // console.log('rapid undo: reinserting object')
-            worldFuncContext.admitToAbyss([])
+            admitToAbyss([])
           }
           return
         }

--- a/src/components/core/Projects.js
+++ b/src/components/core/Projects.js
@@ -9,21 +9,28 @@ should this component have a separate ProjectContext that it passes down for pro
 
 import React, {useContext, useState, useEffect} from 'react'
 import {cameraContext} from './Camera'
+import {physicsContext} from './Physics'
+
 import shallow from 'zustand/shallow'
 
-import {WorldFunctions, userStore} from '../../App'
+import {userStore} from '../../App'
 
 function Projects({children}){
 
     const {cam, setCam} = useContext(cameraContext)
+    const {abyss, admitToAbyss} = useContext(physicsContext)
 
-    const {abyss} = useContext(WorldFunctions)
     const {select, selected} = userStore()
 
     const [alone, projectIsAlone] = useState(null) //for telling a project when the others are all in abyss
     //check if abyss has every project but the selected one
     useEffect(()=>{
-        if(abyss.length === children.length-1 && selected){ //need a way to get actual # of projects
+       if(!selected){
+            admitToAbyss([])
+        }
+    }, [selected])
+    useEffect(()=>{
+        if(abyss.length === children.length-1 && selected){ 
           projectIsAlone(selected)
         }
         else projectIsAlone(null)

--- a/src/components/core/Projects.js
+++ b/src/components/core/Projects.js
@@ -9,14 +9,16 @@ should this component have a separate ProjectContext that it passes down for pro
 
 import React, {useContext, useState, useEffect} from 'react'
 import {cameraContext} from './Camera'
+import shallow from 'zustand/shallow'
 
-import {WorldFunctions} from '../../App'
+import {WorldFunctions, userStore} from '../../App'
 
 function Projects({children}){
 
     const {cam, setCam} = useContext(cameraContext)
 
-    const {select, selected, abyss} = useContext(WorldFunctions)
+    const {abyss} = useContext(WorldFunctions)
+    const {select, selected} = userStore(store => ({select: store.select, selected: store.selected}), shallow)
 
     const [alone, projectIsAlone] = useState(null) //for telling a project when the others are all in abyss
     //check if abyss has every project but the selected one

--- a/src/components/core/Projects.js
+++ b/src/components/core/Projects.js
@@ -18,7 +18,7 @@ function Projects({children}){
     const {cam, setCam} = useContext(cameraContext)
 
     const {abyss} = useContext(WorldFunctions)
-    const {select, selected} = userStore(store => ({select: store.select, selected: store.selected}), shallow)
+    const {select, selected} = userStore()
 
     const [alone, projectIsAlone] = useState(null) //for telling a project when the others are all in abyss
     //check if abyss has every project but the selected one

--- a/src/components/projects/Scorecard/SCPage.js
+++ b/src/components/projects/Scorecard/SCPage.js
@@ -4,9 +4,11 @@ import bogan from 'boganipsum'
 
 export const SCPage = () => {
     return(
-        <React.Fragment>
+        <div key = 'fuckyou'>
             <h1> Fuck you </h1>
-            {bogan({paragraphs: 10})}
-        </React.Fragment>
+            {[0,0,0,0,0,0,0].map((c,i)=>{
+                return <p key = {i}> {bogan({paragraphs: 1})} </p>
+            })}
+        </div>
     )
 }

--- a/src/components/projects/Scorecard/SCPage.js
+++ b/src/components/projects/Scorecard/SCPage.js
@@ -1,0 +1,12 @@
+
+import React from 'react'
+import bogan from 'boganipsum'
+
+export const SCPage = () => {
+    return(
+        <React.Fragment>
+            <h1> Fuck you </h1>
+            {bogan({paragraphs: 10})}
+        </React.Fragment>
+    )
+}

--- a/src/components/projects/Scorecard/index.js
+++ b/src/components/projects/Scorecard/index.js
@@ -12,7 +12,7 @@ import {toRads} from '../../../utils/3d'
 import {Body} from '../../core/Body'
 import Model from './SCModel'
 
-import {UserContext} from '../../../App'
+import {userStore} from '../../../App'
 
 export {SCPage} from './SCPage'
 
@@ -20,7 +20,7 @@ export {SCPage} from './SCPage'
 export function SCBlurb({
     ...props
 }){
-    const {study} = useContext(UserContext)
+    const study = userStore(store => store.study)
     return(
         <React.Fragment>
             <h1>Scorecard of California children's well-being</h1>

--- a/src/components/projects/Scorecard/index.js
+++ b/src/components/projects/Scorecard/index.js
@@ -12,6 +12,26 @@ import {toRads} from '../../../utils/3d'
 import {Body} from '../../core/Body'
 import Model from './SCModel'
 
+import {UserContext} from '../../../App'
+
+export {SCPage} from './SCPage'
+
+
+export function SCBlurb({
+    ...props
+}){
+    const {study} = useContext(UserContext)
+    return(
+        <React.Fragment>
+            <h1>Scorecard of California children's well-being</h1>
+            <p>A web tool for exploring children's health, education, and welfare data in California and all its counties,
+            filterable by race and year. Designed and developed for Children Now, a nonprofit that uses it in meetings with local leaders
+            (government, foundations, nonprofits) to highlight and advocate for children's needs.</p>
+            <button onClick = {()=> study('scorecard')}> View case study </button>
+        </React.Fragment>
+    )
+}
+
 export default function Scorecard({
     onClick = () => console.log('clicked project'), 
     selected = false,
@@ -43,8 +63,6 @@ export default function Scorecard({
 
     //tracks whether forced motion on a body is done (the body component will use the callback when its own tween finishes)
     const [doneForcing, changeDoneForcing] = useState(false)
-
-
 
     return( <Body 
         name = 'scorecard'


### PR DESCRIPTION
While trying to create a "userContext" that'd contain the selection / study (blurb+page) states and setters, ran into https://github.com/react-spring/react-three-fiber/issues/262. That led to setting up zustand to handle a userStore which seems to work well here. Also migrated `abyss` to live with physicsProvider - natural and allows for removal of worldFuncContext